### PR TITLE
Remove mention of specific team name and make the content generic

### DIFF
--- a/src/main/java/com/bot/mrgerkins/domain/utils/GithubUtils.java
+++ b/src/main/java/com/bot/mrgerkins/domain/utils/GithubUtils.java
@@ -180,7 +180,7 @@ public class GithubUtils {
                 emailClientWrapper
                         .sendMail(emailConfig.getSender(),
                                 new StringBuilder(author).append("@").append(emailConfig.getDomain()).toString(),
-                                "Symphony Pull Request Update",
+                                repoFullName + " Pull Request Update",
                                 templateUtils.materializeTemplateFile(emailTemplate, context));
             }
             catch (EmailException e) {
@@ -224,17 +224,18 @@ public class GithubUtils {
 
     public void notifyRelease(ReleasePayload request) throws EmailException {
 
+        final String repoFullName = request.getRepository().getFullName();
+        final String tagName = request.getRelease().getTagName();
+
         HashMap<String, String> context = new HashMap<>();
-        context.put("repository", request.getRepository().getFullName());
+        context.put("repository", repoFullName);
         context.put("releaseInfo", request.getRelease().getHtmlUrl());
-        context.put("tag", request.getRelease().getTagName());
-        context.put("releaseUrl",
-                new StringBuilder(request.getRepository().getHtmlUrl()).append("/blob/").append(request.getRelease()
-                        .getTagName()).append("/").append(RELEASE_NOTES_FILE_PATH).toString());
+        context.put("tag", tagName);
+        context.put("releaseUrl", new StringBuilder(request.getRepository().getHtmlUrl()).append("/blob/").append(tagName).append("/").append(RELEASE_NOTES_FILE_PATH).toString());
         emailClientWrapper
                 .sendMail(emailConfig.getSender(),
-                        emailConfig.getReleaseNotifyDlForRepo(request.getRepository().getFullName()),
-                        "Symphony Release Update",
+                        emailConfig.getReleaseNotifyDlForRepo(repoFullName),
+                        repoFullName + " Release Update",
                         templateUtils
                                 .materializeTemplateFile(templateUtils.readTemplateFile(NOTIFY_RELEASE_TEMPLATE_PATH),
                                         context));

--- a/src/main/resources/email/notifyReleaseComplete.html
+++ b/src/main/resources/email/notifyReleaseComplete.html
@@ -1,12 +1,11 @@
 <html>
     <body>
     <p>Hi,</p>
-    <p>Symphony ($repository) release for tag $tag has completed successfully.</p>
+    <p>$repository release for tag $tag has completed successfully.</p>
     <p>The release notes can be found <a href="$releaseUrl">here</a>.</p>
     <p>The release information can be found <a href="$releaseInfo">here</a>.</p>
     <p>Looking forward to your future contributions to $repository</p>
     <p></p>
-    <p>Thanks,</p>
-    <p>Symphony Team</p>
+    <p>Thank You</p>
     </body>
 </html>

--- a/src/main/resources/email/notifyTagPRAuthors.html
+++ b/src/main/resources/email/notifyTagPRAuthors.html
@@ -1,12 +1,10 @@
 <html>
     <body>
         <p>Hi,</p>
-        <p>Greetings from the Symphony team!</p>
         <p>A new tag $releaseVersion has been created for $repository. Your following PR(s) are a part of it:</p>
         <ul>
              $prList
         </ul>
-        <p>Thanks,</p>
-        <p>The Symphony Team</p>
+        <p>Thank You</p>
     </body>
 </html>

--- a/src/test/java/com/bot/mrgerkins/domain/utils/GithubUtilsTest.java
+++ b/src/test/java/com/bot/mrgerkins/domain/utils/GithubUtilsTest.java
@@ -31,12 +31,13 @@ import static org.assertj.core.api.Assertions.*;
  */
 public class GithubUtilsTest {
 
-    private static final String REPO_FULL_NAME = "bijilap/mr-gerkins";
+    private static final String BIJILAP_REPO_FULL_NAME = "bijilap/mr-gerkins";
     private static final String TAG_BRANCH = "master";
     private static final String LATEST_RELEASE_TAG = "v2.0.6";
 
     private static final String RELEASEEVENT_WH_FILE = "src/test/resources/github/ReleaseEventWebhook.json";
     private static final String GITHUB_URL = "github.com";
+    private static final String BAXTERTHEHACKER_REPO_FULL_NAME = "baxterthehacker/public-repo";
 
     @Mock
     private GithubClientWrapper githubClientWrapper;
@@ -75,7 +76,7 @@ public class GithubUtilsTest {
 
         //service calls
         //result: (PR#, Author, Title)
-        List<Triple<String, String, String>> result =  githubUtils.getListOfMergedPRs(REPO_FULL_NAME, TAG_BRANCH);
+        List<Triple<String, String, String>> result =  githubUtils.getListOfMergedPRs(BIJILAP_REPO_FULL_NAME, TAG_BRANCH);
 
         //assertions
         assertThat(result).hasSize(2);
@@ -97,12 +98,12 @@ public class GithubUtilsTest {
         Mockito.doAnswer(invocationOnMock -> {
             Object args[] = invocationOnMock.getArguments();
             assertThat(args).hasSize(4);
-            assertThat(args).contains(senderEmail,notifyDlEmail, "Symphony Release Update");
+            assertThat(args).contains(senderEmail,notifyDlEmail, BAXTERTHEHACKER_REPO_FULL_NAME + " Release Update");
             return invocationOnMock;
         }).when(emailClientWrapper).sendMail(anyString(), anyString(), anyString(), anyString());
 
         when(emailConfig.getSender()).thenReturn(senderEmail);
-        when(emailConfig.getReleaseNotifyDlForRepo("baxterthehacker/public-repo")).thenReturn(notifyDlEmail);
+        when(emailConfig.getReleaseNotifyDlForRepo(BAXTERTHEHACKER_REPO_FULL_NAME)).thenReturn(notifyDlEmail);
 
         githubUtils.notifyRelease(releasePayload);
     }
@@ -134,7 +135,7 @@ public class GithubUtilsTest {
         }).when(githubUtils).updateFileInRepo(anyString(), anyString(), anyString(), anyString());
 
 
-        githubUtils.generateReleaseNotes(REPO_FULL_NAME, TAG_BRANCH, LATEST_RELEASE_TAG);
+        githubUtils.generateReleaseNotes(BIJILAP_REPO_FULL_NAME, TAG_BRANCH, LATEST_RELEASE_TAG);
     }
 
     private void mockGithubCompareTagResponse() throws IOException, HttpException {
@@ -152,9 +153,9 @@ public class GithubUtilsTest {
                 .addCommit(githubCommitRecord2).addCommit(githubCommitRecord3).build();
 
         //define mocks and stubs
-        when(githubClientWrapper.getLatestRelease(REPO_FULL_NAME))
+        when(githubClientWrapper.getLatestRelease(BIJILAP_REPO_FULL_NAME))
                 .thenReturn(new GithubReleaseBuilder().tagName(LATEST_RELEASE_TAG).build());
-        when(githubClientWrapper.compareCommitTags(REPO_FULL_NAME, LATEST_RELEASE_TAG, TAG_BRANCH))
+        when(githubClientWrapper.compareCommitTags(BIJILAP_REPO_FULL_NAME, LATEST_RELEASE_TAG, TAG_BRANCH))
                 .thenReturn(githubCompareTag);
     }
 }


### PR DESCRIPTION
Symphony is a team code name @PayPal and should not be used on our open source project.
Removing or Replacing Symphony with "Mr. Gerkins" as and where appropriate